### PR TITLE
Add initial `WP::request()` & friends API method with unslashing, optional default, optional sanitization.

### DIFF
--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -784,35 +784,38 @@ class WP {
 	 * Retrieve a value from $_REQUEST according to a $path and/or $schama.
 	 */
 	public static function request( $path, $default = null, $schema = false ) {
-		return self::_superglobal_access_helper( 'request', $path, $default, $schema );
+		return self::_superglobal_access_helper( '_REQUEST', $path, $default, $schema );
 	}
 
 	/**
 	 * Retrieve a value from $_GET according to a $path and/or $schama.
 	 */
 	public static function get( $path, $default = null, $schema = false ) {
-		return self::_superglobal_access_helper( 'get', $path, $default, $schema );
+		return self::_superglobal_access_helper( '_GET', $path, $default, $schema );
 	}
 
 	/**
 	 * Retrieve a value from $_POST according to a $path and/or $schama.
 	 */
 	public static function post( $path, $default = null, $schema = false ) {
-		return self::_superglobal_access_helper( 'post', $path, $default, $schema );
+		return self::_superglobal_access_helper( '_POST', $path, $default, $schema );
 	}
 
 	/**
 	 *
-	 * @param string       $var     The global to access, sans underscore prefix.
+	 * @param string       $var     The global to access.
 	 * @param string|array $path    The path to the value to fetch. See _wp_array_get().
 	 * @param mixed|null   $default The default value if $path is not set.
 	 * @param string|arrau $schema  The primitive type of the value to return, or a Schema defining the value of the item. See rest_sanitize_value_from_schema().
 	 * @return mixed|WP_Error The request value, and if a $schema is passed, the sanitized value or a WP_Error instance if the value cannot be safely sanitized.
 	 */
 	protected static function _superglobal_access_helper( $var, $path, $default = null, $schema = false ) {
-		$var   = ltrim( $var, '_' );
+		if ( ! isset( $GLOBALS[ $var ] ) ) {
+			return $default;
+		}
+
 		$path  = is_array( $path ) ? $path : array( $path );
-		$value = _wp_array_get( $GLOBALS[ strtoupper( "_{$var}" ) ], $path, null );
+		$value = _wp_array_get( $GLOBALS[ $var ], $path, null );
 
 		if ( is_null( $value ) ) {
 			return $default;
@@ -823,7 +826,8 @@ class WP {
 		// Coerce it into the appropriate type.
 		if ( $schema ) {
 			$schema = is_string( $schema ) ? array( 'type' => $schema ) : $schema;
-			$value  = rest_sanitize_value_from_schema( $value, $schema, "WP::{$var}()" );
+			$caller = strtolower( ltrim( $var, '_' ) );
+			$value  = rest_sanitize_value_from_schema( $value, $schema, "WP::{$caller}()" );
 		}
 
 		return $value;

--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -779,4 +779,53 @@ class WP {
 		 */
 		do_action_ref_array( 'wp', array( &$this ) );
 	}
+
+	/**
+	 * Retrieve a value from $_REQUEST according to a $path and/or $schama.
+	 */
+	public static function request( $path, $default = null, $schema = false ) {
+		return self::_superglobal_access_helper( 'request', $path, $default, $schema );
+	}
+
+	/**
+	 * Retrieve a value from $_GET according to a $path and/or $schama.
+	 */
+	public static function get( $path, $default = null, $schema = false ) {
+		return self::_superglobal_access_helper( 'get', $path, $default, $schema );
+	}
+
+	/**
+	 * Retrieve a value from $_POST according to a $path and/or $schama.
+	 */
+	public static function post( $path, $default = null, $schema = false ) {
+		return self::_superglobal_access_helper( 'post', $path, $default, $schema );
+	}
+
+	/**
+	 *
+	 * @param string       $var     The global to access, sans underscore prefix.
+	 * @param string|array $path    The path to the value to fetch. See _wp_array_get().
+	 * @param mixed|null   $default The default value if $path is not set.
+	 * @param string|arrau $schema  The primitive type of the value to return, or a Schema defining the value of the item. See rest_sanitize_value_from_schema().
+	 * @return mixed|WP_Error The request value, and if a $schema is passed, the sanitized value or a WP_Error instance if the value cannot be safely sanitized.
+	 */
+	protected static function _superglobal_access_helper( $var, $path, $default = null, $schema = false ) {
+		$var   = ltrim( $var, '_' );
+		$path  = is_array( $path ) ? $path : array( $path );
+		$value = _wp_array_get( $GLOBALS[ strtoupper( "_{$var}" ) ], $path, null );
+
+		if ( is_null( $value ) ) {
+			return $default;
+		}
+
+		$value = wp_unslash( $value );
+
+		// Coerce it into the appropriate type.
+		if ( $schema ) {
+			$schema = is_string( $schema ) ? array( 'type' => $schema ) : $schema;
+			$value  = rest_sanitize_value_from_schema( $value, $schema, "WP::{$var}()" );
+		}
+
+		return $value;
+	}
 }


### PR DESCRIPTION
WIP idea.

```php
http://example.org/?foo[]=bar&baz[bar]=3

// Sub-key access
$value = WP::get( [ 'baz', 'bar' ], 1, 'integer'  );
var_dump( $value ); // int 3

// Sub key => Default
$value = WP::get( [ 'foo', 'unset', 'value' ], 1, 'integer'  );
var_dump( $value ); // int 1

// Something that's actually kind meh.. "foo[]=bar" => float 1 ??
$value = WP::get( 'foo', false, 'number'  );
var_dump( $value ); // float 1 - not an array.

// Something that's better than worst case, "foo[]=.." => string val "Array"
$value = WP::get( 'foo', 'default value here', 'string'  );
var_dump( $value ); // string 'Array'
```