### PR TITLE
Update example IP address

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -548,7 +548,7 @@ function send_origin_headers() {
  *
  * - `http://192.168.0.1/caniload.php` - IP address from LAN network.
  *   This can be changed with the {@see 'http_request_host_is_external'} filter.
- * - `http://198.143.164.252:81/caniload.php` - By default, only ports 80, 443, and 8080 are allowed.
+ * - `http://198.51.100.50:81/caniload.php` - By default, only ports 80, 443, and 8080 are allowed.
  *   This can be changed with the {@see 'http_allowed_safe_ports'} filter.
  *
  * @since 3.5.2


### PR DESCRIPTION
A WordPress.org IP address (which may change over time) is currently used within a docblock, we should update this to use an IP from a TEST-NET-xx IP range.

Trac ticket: https://core.trac.wordpress.org/ticket/65229

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
